### PR TITLE
Check for time at every node of the tree

### DIFF
--- a/include/montezuma/engine.h
+++ b/include/montezuma/engine.h
@@ -76,6 +76,9 @@ namespace montezuma
         unsigned int tableEntries_;
         line globalPvLine_;
         bool usingPreviousLine_;
+        bool usingTime_;
+        unsigned long int limitTime_;
+        std::chrono::time_point<std::chrono::high_resolution_clock> startTimeSearch_;
         unsigned int wTime_;
         unsigned int bTime_;
         unsigned int maxSearchDepth_{6};


### PR DESCRIPTION
Modifies time management. Instead of checking if there is time left only after every iterative deepening iteration, check at every evaluated node